### PR TITLE
Make it installable

### DIFF
--- a/rd-docker-install
+++ b/rd-docker-install
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+INSTALL_DIR="/opt/rd-docker"
+BIN_DIR="/usr/local/bin"
+REPOSITORY="https://github.com/ResultadosDigitais/rd-docker.git"
+
+clone_repository() {
+  git clone "$REPOSITORY" "$INSTALL_DIR"
+}
+
+create_symlink() {
+  ln -s "${INSTALL_DIR}/rd-docker" "$BIN_DIR"
+}
+
+do_install() {
+  clone_repository
+  create_symlink
+}
+
+do_install

--- a/rd-docker-install
+++ b/rd-docker-install
@@ -17,6 +17,10 @@ check_for_sudo() {
   fi
 }
 
+command_exists() {
+  command -v "$@" > /dev/null 2>&1
+}
+
 check_if_already_installed() {
   if [ -d "$INSTALL_DIR" ]; then
     echo_command "You already have rd-docker installed. To reinstall it you must first uninstall it."
@@ -39,12 +43,51 @@ create_symlink() {
   ln -sf "${INSTALL_DIR}/rd-docker" "$BIN_DIR"
 }
 
+install_docker() {
+  if command_exists "docker"; then
+    echo_command "Docker engine is already installed on your system"
+    return
+  fi
+  echo_command "Installing Docker Engine"
+  curl -fsS https://get.docker.com/ | bash
+}
+
+install_docker_compose() {
+  if command_exists "docker-compose"; then
+    echo_command "Docker Compose is already installed on your system"
+    return
+  fi
+  echo_command "Installing Docker Compose"
+  curl -L https://github.com/docker/compose/releases/download/1.6.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+}
+
+install_engine(){
+  case `uname` in
+    'Linux')
+      install_docker
+      install_docker_compose
+      ;;
+    'Darwin')
+      echo_command "Please follow the following instructions to install docker engine on Mac OS X"
+      echo_command "https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker#mac-os-x-109"
+      ;;
+    *)
+      echo_command "Failed to automatically install Docker engine and Docker Compose."
+      echo_command "Please check the following link for installing it in your OS and"
+      echo_command "if there is no information, please update it."
+      echo_command "https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker \n"
+      ;;
+  esac
+}
+
 do_install() {
   check_if_already_installed
   echo_command "Initializing rd-docker instalation proccess"
   clone_repository
   create_symlink
-  echo_command "Instalation finished successfully"
+  install_engine
+  echo_command "Instalation finished successfully\n"
 }
 
 check_for_sudo

--- a/rd-docker-install
+++ b/rd-docker-install
@@ -10,6 +10,13 @@ echo_command() {
   echo "$command_indicator $1"
 }
 
+check_for_sudo() {
+  if [ $(id -u) -ne 0 ] ; then
+    echo_command "Please run as root"
+    exit 1
+  fi
+}
+
 clone_repository() {
   echo_command "Clonning repository"
   git clone "$REPOSITORY" "$INSTALL_DIR"
@@ -27,4 +34,5 @@ do_install() {
   echo_command "Instalation finished successfully"
 }
 
+check_for_sudo
 do_install

--- a/rd-docker-install
+++ b/rd-docker-install
@@ -17,6 +17,18 @@ check_for_sudo() {
   fi
 }
 
+check_if_already_installed() {
+  if [ -d "$INSTALL_DIR" ]; then
+    echo_command "You already have rd-docker installed. To reinstall it you must first uninstall it."
+    echo_command "You can do this by running the following command:"
+    echo_command ""
+    echo_command "$ sudo rm -rf $INSTALL_DIR $BIN_DIR/rd-docker"
+    echo_command ""
+    echo_command "After that run this script again to reinstall rd-docker."
+    exit 1
+  fi
+}
+
 clone_repository() {
   echo_command "Clonning repository"
   git clone "$REPOSITORY" "$INSTALL_DIR"
@@ -24,10 +36,11 @@ clone_repository() {
 
 create_symlink() {
   echo_command "Creating symlink"
-  ln -s "${INSTALL_DIR}/rd-docker" "$BIN_DIR"
+  ln -sf "${INSTALL_DIR}/rd-docker" "$BIN_DIR"
 }
 
 do_install() {
+  check_if_already_installed
   echo_command "Initializing rd-docker instalation proccess"
   clone_repository
   create_symlink

--- a/rd-docker-install
+++ b/rd-docker-install
@@ -41,8 +41,12 @@ check_if_already_installed() {
   fi
 }
 
-clone_repository() {
+check_dependencies() {
   check_dependency "git"
+  check_dependency "curl"
+}
+
+clone_repository() {
   echo_command "Clonning repository"
   git clone "$REPOSITORY" "$INSTALL_DIR"
 }
@@ -52,46 +56,65 @@ create_symlink() {
   ln -sf "${INSTALL_DIR}/rd-docker" "$BIN_DIR"
 }
 
-install_docker() {
-  if command_exists "docker"; then
-    echo_command "Docker engine is already installed on your system"
-    return
+is_installed() {
+  if command_exists "$1";then
+    echo_command "$1 is already installed on your system"
+    true
+  else
+    false
   fi
+}
+
+try_to_install_engine_on_linux() {
+  if ! is_installed "docker"; then
+    install_docker
+  fi
+
+  if ! is_installed "docker-compose"; then
+    install_docker_compose
+  fi
+}
+
+install_docker() {
   echo_command "Installing Docker Engine"
   curl -fsS https://get.docker.com/ | bash
 }
 
 install_docker_compose() {
-  if command_exists "docker-compose"; then
-    echo_command "Docker Compose is already installed on your system"
-    return
-  fi
   echo_command "Installing Docker Compose"
   curl -L https://github.com/docker/compose/releases/download/1.6.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
 }
 
+show_instructions_for_mac_os_x() {
+  echo_command "Please follow the following instructions to install docker engine on Mac OS X"
+  echo_command "https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker#mac-os-x-109"
+}
+
+show_instructions_for_other_os() {
+  echo_command "Failed to automatically install Docker engine and Docker Compose."
+  echo_command "Please check the following link for installing it in your OS and"
+  echo_command "if there is no information, please update it."
+  echo_command "https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker \n"
+}
+
 install_engine(){
   case `uname` in
     'Linux')
-      install_docker
-      install_docker_compose
+      try_to_install_engine_on_linux
       ;;
     'Darwin')
-      echo_command "Please follow the following instructions to install docker engine on Mac OS X"
-      echo_command "https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker#mac-os-x-109"
+      show_instructions_for_mac_os_x
       ;;
     *)
-      echo_command "Failed to automatically install Docker engine and Docker Compose."
-      echo_command "Please check the following link for installing it in your OS and"
-      echo_command "if there is no information, please update it."
-      echo_command "https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker \n"
+      show_instructions_for_other_os
       ;;
   esac
 }
 
 do_install() {
   check_if_already_installed
+  check_dependencies
   echo_command "Initializing rd-docker instalation proccess"
   clone_repository
   create_symlink

--- a/rd-docker-install
+++ b/rd-docker-install
@@ -4,17 +4,27 @@ INSTALL_DIR="/opt/rd-docker"
 BIN_DIR="/usr/local/bin"
 REPOSITORY="https://github.com/ResultadosDigitais/rd-docker.git"
 
+command_indicator=">"
+
+echo_command() {
+  echo "$command_indicator $1"
+}
+
 clone_repository() {
+  echo_command "Clonning repository"
   git clone "$REPOSITORY" "$INSTALL_DIR"
 }
 
 create_symlink() {
+  echo_command "Creating symlink"
   ln -s "${INSTALL_DIR}/rd-docker" "$BIN_DIR"
 }
 
 do_install() {
+  echo_command "Initializing rd-docker instalation proccess"
   clone_repository
   create_symlink
+  echo_command "Instalation finished successfully"
 }
 
 do_install

--- a/rd-docker-install
+++ b/rd-docker-install
@@ -21,6 +21,14 @@ command_exists() {
   command -v "$@" > /dev/null 2>&1
 }
 
+check_dependency() {
+  if ! command_exists "$1"; then
+    echo_command "Missing dependency: $1 must be installed."
+    echo_command "Please install $1 first then run this installer again."
+    exit 1
+  fi
+}
+
 check_if_already_installed() {
   if [ -d "$INSTALL_DIR" ]; then
     echo_command "You already have rd-docker installed. To reinstall it you must first uninstall it."
@@ -34,6 +42,7 @@ check_if_already_installed() {
 }
 
 clone_repository() {
+  check_dependency "git"
   echo_command "Clonning repository"
   git clone "$REPOSITORY" "$INSTALL_DIR"
 }


### PR DESCRIPTION
Adds an installation script which clones rd-docker project to `/opt` and creates a symlink on `/usr/local/bin`

After `rd-docker` is installed, eh script also installs docker and docker-compose if it is not installed yet.

To test run the following command in a shell window to install the script:

```
curl -sSL https://raw.githubusercontent.com/ResultadosDigitais/rd-docker/make-it-installable/rd-docker-install | sudo sh
```

Then open a new shell session (a new terminal window or simply type `bash`) and run the following command:

```
rd-docker
```

the output should be the following:

```
==========> Docker: 
> Command not found
> RD Docker usage:
>   install    - install docker and dependencies
>   reset      - stop and remove all containers and drops all volumes within the compose 
>   stop       - stop and remove all containers within the compose
>   start, s   - execute web aplication on main container
>   console, c - execute bash console on main container
>   exec, e    - ensure running infrastructure and execute a command in a given app container (ex: exec db "psql -U postgres").
>                for help on this subcommand (exec help)
```