### PR TITLE
Run rd-docker using a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,6 @@ The prefix which will be used on container names. Project folder name is used if
 APP_PREFIX="rdstation_"
 ```
 
-#### VOLUME_NAMES (optional):
-
-The volume names to rd-docker create and ensure the existence before starting containers.
-
-```
-VOLUME_NAMES=(
-  "rdstation_postgres"
-  "rdstation_mongo"
-  "rdstation_redis"
-)
-```
-
 ## Usage
 
 All rd-docker commands should be executed on your project root folder.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# rd-docker
+
+A client that controls Docker containers in the development environment. It is designed to work alongside Docker Compose and has the objective to make easier common operations docker operations on development environment.
+
+## Installation
+
+To install rd-docker type the following in a terminal window:
+
+```
+curl -sSL https://raw.githubusercontent.com/ResultadosDigitais/rd-docker/master/rd-docker-install | sudo sh
+```
+
+It will install rd-docker in your environment and if you use linux it will try to install Docker and Docker Compose as well. On Mac OS X you will need to manually install Docker after rd-docker is installed.
+
+## Configuration
+
+To configure rd-docker first be shure to have docker-compose.yml configured on your project folder. Then crate a file named **rd-docker.config** in your project folder like the following:
+
+```
+IMAGE=resultadosdigitais/rdstation-dev:alpha
+MAIN_CONTAINER_NAME="web"
+```
+
+### Configuration options
+
+#### IMAGE (required):
+
+Docker image of the main application container. rd-docker will use it to auto update before server starts.
+
+#### MAIN_CONTAINER_NAME (required):
+
+The name of the main container on docker-compose.yml. It's the container where the project server runs.
+
+#### APP_PREFIX (optional):
+
+The prefix which will be used on container names. Project folder name is used if it's omitted. Example:
+
+```
+APP_PREFIX="rdstation_"
+```
+
+#### VOLUME_NAMES (optional):
+
+The volume names to rd-docker create and ensure the existence before starting containers.
+
+```
+VOLUME_NAMES=(
+  "rdstation_postgres"
+  "rdstation_mongo"
+  "rdstation_redis"
+)
+```
+
+## Usage
+
+All rd-docker commands should be executed on your project root folder.
+
+Type the following to start your application server:
+
+```bash
+$ rd-docker start
+```
+
+To access a bash console inside your main container use the following command:
+
+```bash
+$ rd-docker console
+```
+
+To stop and remove all your project containers use the following:
+
+```bash
+$ rd-docker stop
+```
+
+If you want to run any other command on any of your Docker Compose containers use the following:
+
+```bash
+$ rd-docker exec "container name" "command"
+```
+
+These are the most common rd-docker commands. To see a list of all commands type the following:
+
+```bash
+$ rd-docker help
+```
+
+## Troubleshooting
+
+If rd-docker says that `docker` or `docker-compose` commands doesn't exist it means the there was some problem on docker automatic installation. When it occurs you must install them manually. Go to the following links to know more about manual installation:
+
+[Docker Engine instalation](https://docs.docker.com/engine/installation/linux/) (Linux)
+
+[Docker Compose instalation](https://docs.docker.com/compose/install/) (Linux)
+
+[Docker Toolbox instalation](https://github.com/ResultadosDigitais/rd-product-team-wiki/wiki/Como-configurar-o-ambiente-de-desenvolvimento-utilizando-Docker#mac-os-x-109) (Mac OS X 10.9+)

--- a/rd-docker
+++ b/rd-docker
@@ -2,8 +2,20 @@
 
 command=$1
 
+CURRENT_DIR="$(pwd)"
+CONFIG_FILE="rd-docker.config"
 header_indicator="==========>"
 command_indicator=">"
+
+load_config_file(){
+  file_path="$CURRENT_DIR/$CONFIG_FILE"
+
+  if [[ ! -f "$file_path" ]]; then
+    echo_command "Configuration file missing: rd-docker.config not found in current directory"
+    exit 1
+  fi
+  source "$file_path"
+}
 
 get_container_id(){
   app=$1
@@ -34,7 +46,7 @@ ensure_volumes(){
 
 ensure_uptodate_image(){
   echo_command "Checking image updates..."
-  docker pull $IMAGE_NAME:$TAG
+  docker pull $IMAGE
 }
 
 # Housekeeping methods
@@ -123,6 +135,8 @@ show_exec_help(){
   echo_command "    container_app - name of the app container (see 'docker-compose.yml' for container names)"
   echo_command "    command       - command to be run inside the chosen container"
 }
+
+load_config_file
 
 echo "$header_indicator Docker: $command"
 case "$command" in

--- a/rd-docker
+++ b/rd-docker
@@ -35,22 +35,6 @@ get_container_id(){
 }
 
 # Validation methods
-ensure_volume(){
-  volume_id=$(docker volume ls -q | grep $1)
-
-  if [[ "$volume_id" == "" ]]; then
-    echo_command "Creating volume for $1"
-    docker volume create --name $1
-  fi
-}
-
-ensure_volumes(){
-  for i in "${VOLUME_NAMES[@]}"
-  do
-     ensure_volume $i
-  done
-}
-
 ensure_uptodate_image(){
   echo_command "Checking image updates..."
   docker pull $IMAGE
@@ -115,7 +99,6 @@ execute_command() {
 
 raise_infrastructure(){
   echo_command "Raising infrastructure"
-  ensure_volumes
   ensure_uptodate_image
   docker-compose -p $APP_PREFIX run -d --service-ports $MAIN_CONTAINER_NAME tail -f /dev/null
 }

--- a/rd-docker
+++ b/rd-docker
@@ -17,6 +17,13 @@ load_config_file(){
   source "$file_path"
 }
 
+ensure_app_prefix(){
+  if [[ "$APP_PREFIX" == "" ]]; then
+    dirname="${CURRENT_DIR##*/}"
+    APP_PREFIX="$(echo $dirname | sed 's/[-_ ]//g')_"
+  fi
+}
+
 get_container_id(){
   app=$1
 
@@ -110,7 +117,7 @@ raise_infrastructure(){
   echo_command "Raising infrastructure"
   ensure_volumes
   ensure_uptodate_image
-  docker-compose run -d --service-ports $MAIN_CONTAINER_NAME tail -f /dev/null
+  docker-compose -p $APP_PREFIX run -d --service-ports $MAIN_CONTAINER_NAME tail -f /dev/null
 }
 
 # Instrumentation methods
@@ -137,6 +144,7 @@ show_exec_help(){
 }
 
 load_config_file
+ensure_app_prefix
 
 echo "$header_indicator Docker: $command"
 case "$command" in

--- a/rd-docker
+++ b/rd-docker
@@ -32,7 +32,7 @@ validate_config(){
 ensure_app_prefix(){
   if [[ "$APP_PREFIX" == "" ]]; then
     dirname="${CURRENT_DIR##*/}"
-    APP_PREFIX="$(echo $dirname | sed 's/[-_ ]//g')_"
+    APP_PREFIX="$(echo $dirname | sed 's/[-_ ]//g')"
   fi
 }
 
@@ -43,7 +43,7 @@ get_container_id(){
     app=$MAIN_CONTAINER_NAME
   fi
 
-  docker ps | grep $APP_PREFIX$app | awk '{print $1}'
+  docker ps | grep "${APP_PREFIX}_${app}" | awk '{print $1}'
 }
 
 # Validation methods
@@ -55,12 +55,12 @@ ensure_uptodate_image(){
 # Housekeeping methods
 clear_containers(){
   echo_command "Removing possibly existing containers"
-  docker rm -f $(docker ps -a | grep $APP_PREFIX | awk '{ print $1 }') >> /dev/null 2>&1
+  docker rm -f $(docker ps -a | grep "${APP_PREFIX}_" | awk '{ print $1 }') >> /dev/null 2>&1
 }
 
 clear_volumes(){
   echo_command "Removing possibly existing volumes"
-  docker volume rm $(docker volume ls -q | grep $APP_PREFIX) >> /dev/null 2>&1
+  docker volume rm $(docker volume ls -q | grep "${APP_PREFIX}_") >> /dev/null 2>&1
 }
 
 # Infrastructure methods
@@ -112,7 +112,7 @@ execute_command() {
 raise_infrastructure(){
   echo_command "Raising infrastructure"
   ensure_uptodate_image
-  docker-compose -p $APP_PREFIX run -d --service-ports $MAIN_CONTAINER_NAME tail -f /dev/null
+  APP_PREFIX=$APP_PREFIX docker-compose -p $APP_PREFIX run -d --service-ports $MAIN_CONTAINER_NAME tail -f /dev/null
 }
 
 # Instrumentation methods

--- a/rd-docker
+++ b/rd-docker
@@ -17,6 +17,18 @@ load_config_file(){
   source "$file_path"
 }
 
+validate_required_config(){
+  if [[ "${!1}" == "" ]]; then
+    echo_command "Configuration missing: $1 is requried. Please configure it on rd-docker.config"
+    exit 1
+  fi
+}
+
+validate_config(){
+  validate_required_config "IMAGE"
+  validate_required_config "MAIN_CONTAINER_NAME"
+}
+
 ensure_app_prefix(){
   if [[ "$APP_PREFIX" == "" ]]; then
     dirname="${CURRENT_DIR##*/}"
@@ -127,6 +139,7 @@ show_exec_help(){
 }
 
 load_config_file
+validate_config
 ensure_app_prefix
 
 echo "$header_indicator Docker: $command"


### PR DESCRIPTION
## Description

This Pull Request updates rd-docker to use it as an installed application. It reads a config file on current directory and runs the commands using the configuration options in the file.

the README.md has instructions on how to configure it.

## Testing

To test it clone and checkout the rd-docker repository on this branch. Then create the file `rd-docker.config` on rdstation project root folder with the following:

```
IMAGE=resultadosdigitais/rdstation-dev:alpha
APP_PREFIX="rdstation"
MAIN_CONTAINER_NAME="web"
```

Edit `docker-compose.yml` and change volume names following the pattern:

`rdstation_postgres` - change to -> `${APP_PREFIX}_postgres`

This will make the volume names being created with the app_prefix on name.

Then run the commands like the following on rdstation folder:

```bash
../rd-docker/rd-docker start
```

It should work normally.