### PR TITLE
Fix main MAIN_CONTAINER_NAME config and validate APP_PREFIX format

### DIFF
--- a/rd-docker-cli
+++ b/rd-docker-cli
@@ -174,7 +174,7 @@ case "$command" in
     ;;
   start | s)
     echo_command "Starting web application"
-    execute_command "web" "/var/app/entrypoint.sh"
+    execute_command "$MAIN_CONTAINER_NAME" "/var/app/entrypoint.sh"
     exit 0
     ;;
   stop)
@@ -185,7 +185,7 @@ case "$command" in
     ;;
   console | c)
     echo_command "Starting up TTY Session on main container"
-    execute_command "web" "bash"
+    execute_command "$MAIN_CONTAINER_NAME" "bash"
     exit 0
     ;;
   exec | e)

--- a/rd-docker-cli
+++ b/rd-docker-cli
@@ -26,10 +26,21 @@ validate_required_config(){
   fi
 }
 
-validate_required_configs(){
+validate_config_format(){
+  config=$1
+  format=$2
+  message=$3
+  if [[ ! "${!config}" =~ $format ]]; then
+    echo_command "Invalid configuration format: $message"
+    exit 1
+  fi
+}
+
+validate_configs(){
   validate_required_config "IMAGE"
   validate_required_config "MAIN_CONTAINER_NAME"
   validate_required_config "APP_PREFIX"
+  validate_config_format "APP_PREFIX" "^[a-zA-Z0-9]+$" "APP_PREFIX must contain only alphanumeric characters"
 }
 
 ensure_uptodate_rddocker(){
@@ -155,7 +166,7 @@ show_exec_help(){
 
 ensure_uptodate_rddocker
 load_config_file
-validate_required_configs
+validate_configs
 
 echo "$header_indicator Docker: $command"
 case "$command" in


### PR DESCRIPTION
Fixes #4 and #5

Main container name wasn't being used when starting application or console. It forced the container name to always be called "web".

Also, as Docker Compose automatically removes all non alphanumeric characters from prefix, this PR validates its format.