### PR TITLE
Use docker-compose to update image

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,11 @@ It will install rd-docker in your environment and if you use linux it will try t
 To configure rd-docker first be shure to have docker-compose.yml configured on your project folder. Then crate a file named **rd-docker.config** in your project folder like the following:
 
 ```
-IMAGE=resultadosdigitais/rdstation-dev:alpha
 MAIN_CONTAINER_NAME="web"
 APP_PREFIX="rdstation"
 ```
 
 ### Configuration options
-
-#### IMAGE:
-
-Docker image of the main application container. rd-docker will use it to auto update before server starts.
 
 #### MAIN_CONTAINER_NAME:
 

--- a/rd-docker-cli
+++ b/rd-docker-cli
@@ -37,7 +37,6 @@ validate_config_format(){
 }
 
 validate_configs(){
-  validate_required_config "IMAGE"
   validate_required_config "MAIN_CONTAINER_NAME"
   validate_required_config "APP_PREFIX"
   validate_config_format "APP_PREFIX" "^[a-zA-Z0-9]+$" "APP_PREFIX must contain only alphanumeric characters"
@@ -74,7 +73,7 @@ update_rddocker(){
 # Validation methods
 ensure_uptodate_image(){
   echo_command "Checking image updates..."
-  docker pull $IMAGE
+  docker-compose pull $MAIN_CONTAINER_NAME
 }
 
 # Housekeeping methods


### PR DESCRIPTION
Instead of using the `docker pull` command to update the main container image, the `docker-compose pull` command is now used. This change makes possible to remove the IMAGE configuration from rd-docker.config removing the duplication of this information. Now the image information stays only in the docker-compose.yml file.